### PR TITLE
feat: 자동 노션 업로드 기능 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 .vscode
 .env
+.user-setting

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "test": "test"
   },
   "dependencies": {
+    "@notionhq/client": "^2.2.3",
     "discord.js": "^14.7.1",
     "dotenv": "^16.0.3",
     "fs": "^0.0.1-security",

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,7 @@
 import { Client, Collection, Events, GatewayIntentBits } from "discord.js";
 import { token } from "./utils/dotenv.js";
 import { getCommandFiles } from "./utils/index.js";
+import { startStudy, endStudy } from "./utils/study.js";
 
 const botChannelId = "1072156767980625950";
 
@@ -59,9 +60,9 @@ client.on(Events.VoiceStateUpdate, async (oldState, newState) => {
   if (oldState.channelId && !newState.channelId) {
     const message = `@everyone ${user.username} 님이 나감`;
     channel.send(message);
-    // TODO: Notion 모각코 입장 페이지 생성
+    await endStudy(user);
   } else if (!oldState.channelId && newState.channelId) {
-    // TODO: Notion 모각코 퇴장 페이지 생성
+    await startStudy(user);
   }
 });
 

--- a/src/index.js
+++ b/src/index.js
@@ -2,6 +2,7 @@ import { Client, Collection, Events, GatewayIntentBits } from "discord.js";
 import { token } from "./utils/dotenv.js";
 import { getCommandFiles } from "./utils/index.js";
 import { startStudy, endStudy } from "./utils/study.js";
+import { init as settingInit } from "./utils/setting.js";
 
 const botChannelId = "1072156767980625950";
 
@@ -52,6 +53,9 @@ client.on(Events.InteractionCreate, async (interaction) => {
   }
 });
 
+// 설정 불러오기
+settingInit();
+
 // Events 등록
 client.on(Events.VoiceStateUpdate, async (oldState, newState) => {
   const user = await client.users.fetch(newState.id);
@@ -60,9 +64,9 @@ client.on(Events.VoiceStateUpdate, async (oldState, newState) => {
   if (oldState.channelId && !newState.channelId) {
     const message = `@everyone ${user.username} 님이 나감`;
     channel.send(message);
-    await endStudy(user);
+    await endStudy(user.id);
   } else if (!oldState.channelId && newState.channelId) {
-    await startStudy(user);
+    await startStudy(user.id);
   }
 });
 

--- a/src/utils/notion.js
+++ b/src/utils/notion.js
@@ -1,0 +1,107 @@
+import { Client } from "@notionhq/client";
+import { getCurrentKoreanTime, getKorISOString } from "../utils/time.js";
+
+const notion = new Client({ auth: process.env.NOTION_TOKEN });
+const databaseId = "d1b28a88d286408a923301b3d82a30de";
+
+export async function readDatabase() {
+  const response = await notion.databases.query({
+    database_id: databaseId,
+    // filter: {},
+    // sorts: [],
+  });
+}
+
+/**
+ * Create a study page in notion
+ * @param {string} name user who starts a study session
+ * @param {string} notionUserId id of the user
+ * @param {Date} startTime when the session is started
+ * @returns
+ */
+export async function createStudyPage(name, notionUserId, startTime) {
+  const korStartTime = getCurrentKoreanTime(startTime);
+  const response = await createPage({
+    parent: {
+      type: "database_id",
+      database_id: databaseId,
+    },
+    properties: {
+      이름: {
+        title: [
+          {
+            text: {
+              content: `${
+                korStartTime.getUTCMonth() + 1
+              }/${korStartTime.getUTCDate()} ${name}`,
+            },
+          },
+        ],
+      },
+      "시작 시간": {
+        date: {
+          start: getKorISOString(startTime),
+          end: null,
+        },
+      },
+      참여자: {
+        // type: "people",
+        people: [{ object: "user", id: notionUserId }],
+      },
+    },
+  });
+
+  return response;
+}
+
+/**
+ * Update end time of the study notion page
+ * @param {string} pageId page id of the notion page
+ * @param {Date} endTime
+ */
+export async function updateEndTime(pageId, endTime) {
+  await updatePage({
+    page_id: pageId,
+    properties: {
+      "종료 시간": {
+        date: {
+          start: getKorISOString(endTime),
+          end: null,
+        },
+      },
+    },
+    archived: false,
+  });
+}
+
+export async function deleteBlock(blockId) {
+  await catchCommonError(notion.blocks.delete, { block_id: blockId });
+}
+
+export async function restorePage(pageId) {
+  await updatePage({
+    page_id: pageId,
+    archived: false,
+  });
+}
+
+async function createPage(obj) {
+  return await catchCommonError(notion.pages.create, obj);
+}
+
+async function updatePage(obj) {
+  await catchCommonError(notion.pages.update, obj);
+}
+
+async function catchCommonError(func, obj) {
+  try {
+    return await func(obj);
+  } catch (error) {
+    if (error.status === 401) {
+      // invalid token key
+      console.error(`src/utils/notion.js: ${error.code}: ${error.message}`);
+    } else {
+      throw error;
+    }
+  }
+}

--- a/src/utils/notion.js
+++ b/src/utils/notion.js
@@ -2,7 +2,7 @@ import { Client } from "@notionhq/client";
 import { getCurrentKoreanTime, getKorISOString } from "../utils/time.js";
 
 const notion = new Client({ auth: process.env.NOTION_TOKEN });
-const databaseId = "d1b28a88d286408a923301b3d82a30de";
+const databaseId = "25684024fb2b498f962b6ee7abed223f";
 
 export async function readDatabase() {
   const response = await notion.databases.query({
@@ -13,7 +13,7 @@ export async function readDatabase() {
 }
 
 /**
- * Create a study page in notion
+ * Create a study page in [notion](www.notion.so/25684024fb2b498f962b6ee7abed223f)
  * @param {string} name user who starts a study session
  * @param {string} notionUserId id of the user
  * @param {Date} startTime when the session is started

--- a/src/utils/setting.js
+++ b/src/utils/setting.js
@@ -9,7 +9,7 @@ const userSettingPath = path.join(__dirname, ".user-setting");
 let userSettingMap;
 
 // TODO: not real enum (the value can be changed)
-export const SettingProperty = {
+const SettingProperty = {
   NAME: "name",
   NOTION_ID: "notionId",
   DURATION: "duration",
@@ -19,8 +19,9 @@ export function init() {
   const file = fs.readFileSync(userSettingPath);
   if (file) {
     userSettingMap = JSON.parse(file.toString());
+  } else {
+    console.log("[WARNING] No .user-setting");
   }
-  console.log("[WARNING] No .user-setting");
 }
 
 export function getName(id) {

--- a/src/utils/setting.js
+++ b/src/utils/setting.js
@@ -1,0 +1,51 @@
+import * as url from "url";
+import * as path from "path";
+import * as fs from "fs";
+
+const DEFAULT = "default";
+
+const __dirname = url.fileURLToPath(new URL("../..", import.meta.url));
+const userSettingPath = path.join(__dirname, ".user-setting");
+let userSettingMap;
+
+// TODO: not real enum (the value can be changed)
+export const SettingProperty = {
+  NAME: "name",
+  NOTION_ID: "notionId",
+  DURATION: "duration",
+};
+
+export function init() {
+  const file = fs.readFileSync(userSettingPath);
+  if (file) {
+    userSettingMap = JSON.parse(file.toString());
+  }
+  console.log("[WARNING] No .user-setting");
+}
+
+export function getName(id) {
+  return getProperty(id, SettingProperty.NAME);
+}
+
+export function getNotionId(id) {
+  return getProperty(id, SettingProperty.NOTION_ID);
+}
+
+export function getDuration(id) {
+  return getProperty(id, SettingProperty.DURATION);
+}
+
+function getProperty(id, property) {
+  if (!userSettingMap) {
+    return undefined;
+  }
+  const userSetting = userSettingMap[id];
+  if (!userSetting) {
+    return undefined;
+  }
+  let value = userSetting[property];
+  if (value === null) {
+    value = userSettingMap[DEFAULT][property];
+  }
+  return value;
+}

--- a/src/utils/study.js
+++ b/src/utils/study.js
@@ -1,0 +1,73 @@
+import {
+  createStudyPage,
+  updateEndTime,
+  deleteBlock,
+  restorePage,
+} from "./notion.js";
+import { getName, getDuration, getNotionId } from "./setting.js";
+
+const sessionMap = new Map();
+
+export async function startStudy(user) {
+  const userId = user.id;
+  let studySession = sessionMap.get(userId);
+  const duration = getDuration(userId) * 60 * 1000;
+  const now = new Date();
+  let page;
+  if (
+    studySession === undefined ||
+    !studySession.endTime ||
+    now - studySession.endTime > duration // if the time passed enough since the user finished their study session
+  ) {
+    page = await createStudyPage(getName(userId), getNotionId(userId), now);
+    if (!page) {
+      return false;
+    }
+
+    studySession = {
+      pageId: page.id,
+      startTime: now,
+    };
+    sessionMap.set(userId, studySession);
+  } else if (studySession.isEarlyEnded) {
+    studySession.isEarlyEnded = undefined;
+    await restorePage(studySession.pageId);
+  }
+
+  return true;
+}
+
+export async function endStudy(user) {
+  const userId = user.id;
+  const studySession = sessionMap.get(userId);
+  if (studySession === undefined) {
+    return false;
+  }
+
+  const now = new Date();
+  studySession.endTime = now;
+  const duration = getDuration(userId) * 60 * 1000;
+  if (now - studySession.startTime <= duration) {
+    // too short study session - ignore
+    studySession.isEarlyEnded = true;
+    try {
+      await deleteBlock(studySession.pageId);
+    } catch (error) {
+      console.error(`Fail to delete page ${studySession.pageId}`, error);
+      sessionMap.delete(userId);
+    }
+    return false;
+  }
+
+  try {
+    await updateEndTime(studySession.pageId, now);
+  } catch (error) {
+    if (error.status === 400) {
+      console.error(`src/utils/study.js: ${error.code}: ${error.message}`);
+      // notion page is deleted before the user finishes their study session
+      sessionMap.delete(userId);
+    }
+    return false;
+  }
+  return true;
+}

--- a/src/utils/time.js
+++ b/src/utils/time.js
@@ -1,0 +1,14 @@
+export function getCurrentKoreanTime() {
+  const curr = new Date();
+
+  const utc = curr.getTime() + curr.getTimezoneOffset() * 60 * 1000;
+
+  const KR_TIME_DIFF = 9 * 60 * 60 * 1000;
+  return new Date(utc + KR_TIME_DIFF);
+}
+
+export function getKorISOString(now) {
+  const KR_TIME_DIFF = 9 * 60 * 60 * 1000;
+  const kr_curr = new Date(now.getTime() + KR_TIME_DIFF);
+  return kr_curr.toISOString().substring(0, 19) + "+09:00";
+}


### PR DESCRIPTION
### 추가된 기능
- 음성 채널 입장 시, 노션 모각코 데이터베이스에 페이지 작성
    - `이름`: M/D 이름
    - `시작 시간`: 입장한 시각
    - `참여자`: 노션 유저
    - 만약 채널 퇴장 후 5분 이내에 접속했다면, 새로 페이지를 작성하지 않고 이전에 작성한 페이지에 이어서 모각코 진행
    - 만약 채널 입장 후 5분 이내에 퇴장했다가 퇴장 5분 이내에 접속했다면, 삭제했던 페이지 복구
- 음성 채널 퇴장 시, 입장할 때 작성한 페이지에 현재 시간으로 `종료 시간` 작성
    - 만약 채널 입장 후 5분 이내에 퇴장했다면, 입장할 때 작성한 페이지를 삭제
- 사용자 설정 불러오기

### 필요한 초기 설정
- .env
```
DISCORD_TOKEN=
CLIENT_ID=
GUILD_ID=

NOTION_TOKEN= # 노션 워크스페이스의 프라이빗 API token
```
- .user-setting
```JSON
{
  "default": {
    "duration": 5
  },
  "<discordId>": {
    "name": "<실명>",
    "notionId": "<노션 아이디>",
    "duration": "<null 또는 개인이 원하는 입/퇴장 무시 시간 (분)>"
  }
}
```

### 대강의 흐름
![image](https://user-images.githubusercontent.com/105499985/219314157-3b6680c3-8842-48a1-b0f0-2b894dfa87ce.png)

### 문제점
<img src="https://user-images.githubusercontent.com/105499985/219314758-68eb4ff9-0088-4d51-b543-7fd1d2f12679.png" height="500">
- notion bot이 멘션을 해도 알림이 오는 문제 > 엄청 거슬릴 것 같습니다😂

혹시 코드에 이상한 점이나 문제가 되는 네이밍/코드 컨벤션 등 있으면 코드리뷰해주시는 것 환영합니다