### PR TITLE
feat: User 클래스 생성 기능 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 .env
 .vscode
-.user-setting
 node_modules
 out

--- a/README.md
+++ b/README.md
@@ -24,4 +24,5 @@ $ npm run start
 DISCORD_TOKEN=
 CLIENT_ID=
 GUILD_ID=
+NOTION_TOKEN=
 ```

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,6 @@ import User from "./user/index.js";
 
 Discord.init();
 Notion.init();
-User.init();
 
 Discord.run();
+User.init();

--- a/src/notion/index.ts
+++ b/src/notion/index.ts
@@ -9,12 +9,13 @@ export default class Notion {
     this.notion = new Client({ auth: NOTION_TOKEN });
   }
 
-  public static async readDatabase() {
+  public static async readDatabase(databaseId: string) {
     const response = await this.notion.databases.query({
       database_id: databaseId,
       // filter: {},
       // sorts: [],
     });
+    return response;
   }
 
   /**

--- a/src/user/index.ts
+++ b/src/user/index.ts
@@ -1,31 +1,49 @@
-interface UserData {
-  discord: {
-    // DiscordData들
-  };
-  notion: {
-    // NotionData들
-  };
-}
+import Discord from "../discord/index.js";
+import Notion from "../notion/index.js";
+import { usersDatabaseId } from "../utils/index.js";
+import { DiscordUser, NotionUser, UserData } from "../utils/types.js";
 
 export default class User {
   private static users: UserData[];
+  readonly name: string;
+  readonly duration: number; // public?
+  readonly discord: DiscordUser;
+  readonly notion: NotionUser;
 
   public static init() {
-    const users: UserData[] = [];
     (async () => {
-      // TODO
-      // 1. 전체 list 불러오기
-      // for문 돌면서 discord에 각자 유저정보 받아오기
-      // Map 생성
+      const users: UserData[] = [];
+      const response = await Notion.readDatabase(usersDatabaseId);
+
+      for (const result of response.results as any[]) {
+        const name: string = result.properties["이름"].title[0].plain_text;
+        const duration: number = result.properties["duration"].number;
+
+        const discordId: string =
+          result.properties["discordId"].rich_text[0].plain_text;
+        const discordUser: DiscordUser = await Discord.fetchUser(discordId);
+        const notionUser: NotionUser = result.properties["사람"].people[0];
+
+        const user: UserData = {
+          name: name,
+          duration: duration,
+          discord: discordUser,
+          notion: notionUser,
+        };
+        users.push(user);
+      }
+
+      this.users = users;
     })();
-    this.users = users;
   }
 
-  getNotionId(discordId: string) {
-    // TODO
-  }
-
-  getDiscordId(notionId: string) {
-    // TODO
+  constructor(discordId: string) {
+    const user = User.users.find(
+      (user) => user.discord.id === discordId
+    ) as UserData;
+    this.name = user.name;
+    this.duration = user.duration;
+    this.discord = user.discord;
+    this.notion = user.notion;
   }
 }

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -5,13 +5,14 @@ import * as fs from "fs";
 const botChannelId = "1072156767980625950";
 const loungeChannelId = "1068129906686439438";
 const databaseId = "d1b28a88d286408a923301b3d82a30de";
+const usersDatabaseId = "26c53290f0ad49028d93f6475d63291a";
 
 const rootPath = url.fileURLToPath(new URL("../..", import.meta.url));
 const commandsPath = path.join(rootPath, "out", "discord", "commands");
 const eventsPath = path.join(rootPath, "out", "discord", "events");
 const userSettingPath = path.join(rootPath, ".user-setting");
 
-export { botChannelId, loungeChannelId, databaseId };
+export { botChannelId, loungeChannelId, databaseId, usersDatabaseId };
 export { commandsPath, eventsPath, userSettingPath };
 export { DISCORD_TOKEN, CLIENT_ID, GUILD_ID, NOTION_TOKEN } from "./dotenv.js";
 

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -4,16 +4,16 @@ import * as fs from "fs";
 
 const botChannelId = "1072156767980625950";
 const loungeChannelId = "1068129906686439438";
+
 const databaseId = "d1b28a88d286408a923301b3d82a30de";
 const usersDatabaseId = "26c53290f0ad49028d93f6475d63291a";
 
 const rootPath = url.fileURLToPath(new URL("../..", import.meta.url));
 const commandsPath = path.join(rootPath, "out", "discord", "commands");
 const eventsPath = path.join(rootPath, "out", "discord", "events");
-const userSettingPath = path.join(rootPath, ".user-setting");
 
 export { botChannelId, loungeChannelId, databaseId, usersDatabaseId };
-export { commandsPath, eventsPath, userSettingPath };
+export { commandsPath, eventsPath };
 export { DISCORD_TOKEN, CLIENT_ID, GUILD_ID, NOTION_TOKEN } from "./dotenv.js";
 
 export function getFiles(path: string) {

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -1,3 +1,4 @@
+import { PersonUserObjectResponse as NotionUser } from "@notionhq/client/build/src/api-endpoints";
 import {
   Awaitable,
   Client,
@@ -6,6 +7,7 @@ import {
   Collection,
   Interaction,
   SlashCommandBuilder,
+  User as DiscordUser,
 } from "discord.js";
 
 export interface Command {
@@ -26,3 +28,38 @@ export class DiscordClient extends Client {
     this.commands = commands;
   }
 }
+
+export { DiscordUser, NotionUser };
+
+export interface UserData {
+  name: string;
+  duration: number;
+  discord: DiscordUser;
+  notion: NotionUser;
+}
+
+// User {
+//   name: "홍길동",  // 본명
+//   duration: 5,
+//   discord: {
+//     id: '123456789012345678',
+//     bot: false,
+//     system: false,
+//     flags: UserFlagsBitField { bitfield: 0 },
+//     username: 'gildonghong',
+//     discriminator: '1234',  // discord tag
+//     avatar: null,
+//     banner: undefined,
+//     accentColor: undefined
+//   },
+//   notion: {
+//     "object": "user",
+//     "id": "d40e767c-d7af-4b18-a86d-55c61f1e39a4",
+//     "type": "person",
+//     "person": {
+//       "email": "avo@example.org",
+//     },
+//     "name": "길동 홍",
+//     "avatar_url": "https://secure.notion-static.com/e6a352a8-8381-44d0-a1dc-9ed80e62b53d.jpg",
+//   }
+// }

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -31,13 +31,6 @@ export class DiscordClient extends Client {
 
 export { DiscordUser, NotionUser };
 
-export interface UserData {
-  name: string;
-  duration: number;
-  discord: DiscordUser;
-  notion: NotionUser;
-}
-
 // User {
 //   name: "홍길동",  // 본명
 //   duration: 5,


### PR DESCRIPTION
init() 실행시 users가 UserData를 담은 배열을 가지게 됩니다.
```typescript
class User {
  private static users: User[];
  readonly name: string;
  readonly duration: number; // public?
  readonly discord: DiscordUser;
  readonly notion: NotionUser;
}

// example
users: User[] = [
  {
    name: "홍길동",  // 본명
    duration: 5,
    discord: {
      id: '123456789012345678',
      bot: false,
      system: false,
      flags: UserFlagsBitField { bitfield: 0 },
      username: 'gildonghong',
      discriminator: '1234',  // discord tag
      avatar: null,
      banner: undefined,
      accentColor: undefined
    },
    notion: {
      "object": "user",
      "id": "d40e767c-d7af-4b18-a86d-55c61f1e39a4",
      "type": "person",
      "person": {
        "email": "avo@example.org",
      },
      "name": "길동 홍",
      "avatar_url": "https://secure.notion-static.com/e6a352a8-8381-44d0-a1dc-9ed80e62b53d.jpg",
    }
  },
  ...
  (총 4명)
]
```

```
const name = User.getName(discordId)
const duration = User.getDuration(discordId)
const discordUser = User.getDiscordUser(discordId)  // discordUser? notionUser?
const notionUser = User.getNotionUser(discordId)    // 혹은 다른 변수명?
```
