### PR TITLE
feat: 휴식 슬래시커맨드 추가

### DIFF
--- a/src/discord/commands/rest.ts
+++ b/src/discord/commands/rest.ts
@@ -1,0 +1,21 @@
+import { ChatInputCommandInteraction, SlashCommandBuilder } from "discord.js";
+import Study from "../../study/index.js";
+
+const data = new SlashCommandBuilder()
+  .setName("휴식")
+  .setDescription("휴식 toggle");
+
+async function execute(interaction: ChatInputCommandInteraction) {
+  let msg = "";
+  const res = Study.rest(interaction.user.id);
+  if (res === undefined) {
+    msg = "모각코 중이 아닙니다.";
+  } else if (res) {
+    msg = "휴식을 시작합니다.";
+  } else {
+    msg = "휴식을 종료합니다.";
+  }
+  await interaction.reply({ content: msg, ephemeral: true });
+}
+
+export { data, execute };

--- a/src/notion/index.ts
+++ b/src/notion/index.ts
@@ -67,11 +67,16 @@ export default class Notion {
   }
 
   /**
-   * Update end time of the study notion page
+   * Update the study notion page
    * @param {string} pageId page id of the notion page
-   * @param {Date} endTime
+   * @param {Date} endTime time when the study session is ended
+   * @param {number} totalRest total rest time in milisecond
    */
-  public static async updateEndTime(pageId: string, endTime: Date) {
+  public static async updateEnd(
+    pageId: string,
+    endTime: Date,
+    totalRest: number
+  ) {
     await this.updatePage({
       page_id: pageId,
       properties: {
@@ -80,6 +85,9 @@ export default class Notion {
             start: getKorISOString(endTime),
             end: null,
           },
+        },
+        "휴식 시간 (분)": {
+          number: Math.floor(totalRest / 60000),
         },
       },
       archived: false,

--- a/src/study/index.ts
+++ b/src/study/index.ts
@@ -7,6 +7,8 @@ interface StudySession {
   startTime: Date;
   endTime?: Date;
   isEarlyEnded?: boolean;
+  restTime: Date | null;
+  totalRestTime: number;
 }
 
 export default class Study {
@@ -30,33 +32,37 @@ export default class Study {
       try {
         page = await Notion.createStudyPage(name, notion.id, now);
         if (!page) {
-          return false;
+          return;
         }
       } catch (error: any) {
         console.error(
           `src/study/index.ts::startStudy(${userId}) > ${error.code}: ${error.message}`
         );
-        return false;
+        return;
       }
       studySession = {
         pageId: page.id,
         startTime: now,
+        restTime: null,
+        totalRestTime: 0,
       };
       this.sessionMap.set(userId, studySession);
     } else if (studySession.isEarlyEnded) {
       studySession.isEarlyEnded = false;
       await Notion.restorePage(studySession.pageId);
     }
-    return true;
   }
 
   public static async end(userId: string) {
     const studySession: StudySession | undefined = this.sessionMap.get(userId);
     if (studySession === undefined) {
-      return false;
+      return;
     }
     const duration = User.getDuration(userId) * 60 * 1000;
     const now = new Date();
+    if (this.isRest(studySession)) {
+      this.endRest(studySession, now);
+    }
     studySession.endTime = now;
     if (now.getTime() - studySession.startTime.getTime() <= duration) {
       // too short study session - ignore
@@ -67,10 +73,14 @@ export default class Study {
         console.error(`Fail to delete page ${studySession.pageId}`, error);
         this.sessionMap.delete(userId);
       }
-      return false;
+      return;
     }
     try {
-      await Notion.updateEndTime(studySession.pageId, now);
+      await Notion.updateEnd(
+        studySession.pageId,
+        now,
+        studySession.totalRestTime
+      );
     } catch (error: any) {
       console.error(
         `src/study/index.ts::endStudy(${userId}) ${error.code}: ${error.message}`
@@ -79,13 +89,36 @@ export default class Study {
         // notion page is deleted before the user finishes their study session
         this.sessionMap.delete(userId);
       }
-      return false;
     }
-    return true;
   }
 
-  rest() {
-    // TODO
+  public static rest(userId: string) {
+    const studySession = this.sessionMap.get(userId);
+    if (studySession === undefined) {
+      return undefined;
+    }
+    const now = new Date();
+    if (this.isRest(studySession)) {
+      this.endRest(studySession, now);
+      return false;
+    } else {
+      this.startRest(studySession, now);
+      return true;
+    }
+  }
+
+  private static isRest(studySession: StudySession) {
+    return !!studySession.restTime;
+  }
+
+  private static startRest(studySession: StudySession, now: Date) {
+    studySession.restTime = now;
+  }
+
+  private static endRest(studySession: StudySession, now: Date) {
+    studySession.totalRestTime +=
+      now.getTime() - studySession.restTime!.getTime();
+    studySession.restTime = null;
   }
 
   showRank() {

--- a/src/study/index.ts
+++ b/src/study/index.ts
@@ -5,8 +5,8 @@ import Notion from "../notion/index.js";
 interface StudySession {
   pageId: string;
   startTime: Date;
-  endTime?: Date;
-  isEarlyEnded?: boolean;
+  endTime: Date | null;
+  isEarlyEnded: boolean;
   restTime: Date | null;
   totalRestTime: number;
 }
@@ -44,6 +44,8 @@ export default class Study {
         pageId: page.id,
         startTime: now,
         restTime: null,
+        endTime: null,
+        isEarlyEnded: false,
         totalRestTime: 0,
       };
       this.sessionMap.set(userId, studySession);
@@ -51,6 +53,7 @@ export default class Study {
       studySession.isEarlyEnded = false;
       await Notion.restorePage(studySession.pageId);
     }
+    studySession.endTime = null;
   }
 
   public static async end(userId: string) {
@@ -94,7 +97,7 @@ export default class Study {
 
   public static rest(userId: string) {
     const studySession = this.sessionMap.get(userId);
-    if (studySession === undefined) {
+    if (studySession === undefined || studySession.endTime !== null) {
       return undefined;
     }
     const now = new Date();


### PR DESCRIPTION
- [src/discord/commands/rest.ts](https://github.com/chshin59/discord-study-bot/pull/16/commits/478748efb74b5925bcde2fd4dfe8a4ea2354f4e1#diff-361a325d49b1424f2b42151d86718097be67e281dec6bf4cf168af5e590170f1)
    - 휴식 슬래시 커맨드 추가
- [src/study/index.ts](https://github.com/chshin59/discord-study-bot/pull/16/commits/478748efb74b5925bcde2fd4dfe8a4ea2354f4e1#diff-18bc4281037e85154cba0a9070de9500679ed83c5073c9f30e038e197fe189ee)
    - `StudySession` 인터페이스에 `restTime`, `totalRestTime` 변수 추가
        - `restTime`: 휴식 시작 시각
        - `totalRestTime`: 총 휴식 시간(milisecond)
    -  `rest()`: **휴식** 슬래시커맨드 실행 시 현재 상황에 따라 휴식 시작/종료
        - 휴식 시작: `restTime`이 null인 경우, `restTime`에 현재 시간 할당
        - 휴식 종료: `restTime`이 null이 아닌 경우, `totalRestTime` <- `현재 시간값` - `restTime의 시간값`, `restTime` <- null
        - 휴식 불가: studySession이 존재하지 않을 경우
    - `end()`: 휴식 중(`restTime`이 null)인 경우, 휴식 종료 후 스터디 종료 처리
- [src/notion/index.ts](https://github.com/chshin59/discord-study-bot/pull/16/commits/478748efb74b5925bcde2fd4dfe8a4ea2354f4e1#diff-b989458fbff1e807541c0d9a051240c8c427bad324b2ba0ad0beaa0f1c0f3b88)
    - `updateEnd()`: **스터디 종료** 시 `totalRestTime` / 60000을 `휴식 시간 (분)` 속성으로 update 하는 코드 추가

close #15 